### PR TITLE
Reduce GPU utilization

### DIFF
--- a/ClippingPlanesEditor.cpp
+++ b/ClippingPlanesEditor.cpp
@@ -5,9 +5,9 @@
 
 #include <QKeyEvent>
 
-ClippingPlanesEditor::ClippingPlanesEditor(QWidget* parent) :
+ClippingPlanesEditor::ClippingPlanesEditor(GLWidget* parent) :
 	QWidget(parent),
-	_glView(dynamic_cast<GLWidget*>(parent))
+	_glView(parent)
 {
 	setupUi(this);
 }

--- a/ClippingPlanesEditor.h
+++ b/ClippingPlanesEditor.h
@@ -10,7 +10,7 @@ class ClippingPlanesEditor : public QWidget, Ui::ClippingPlanesEditor
 	Q_OBJECT
 
 public:
-	explicit ClippingPlanesEditor(QWidget* parent = nullptr);
+	explicit ClippingPlanesEditor(GLWidget* parent = nullptr);
 	~ClippingPlanesEditor();
 
 protected slots:

--- a/GLWidget.cpp
+++ b/GLWidget.cpp
@@ -3611,6 +3611,8 @@ void GLWidget::mouseMoveEvent(QMouseEvent* e)
 			setCursor(QCursor(QPixmap(":/new/prefix1/res/rotatecursor.png")));
 			_viewMode = ViewMode::NONE;
 		}
+
+		update();
 	}
 	else if ((e->buttons() == Qt::RightButton && e->modifiers() & Qt::ControlModifier) || (e->buttons() == Qt::LeftButton && _viewPanning))
 	{
@@ -3622,6 +3624,8 @@ void GLWidget::mouseMoveEvent(QMouseEvent* e)
 
 		_rightButtonPoint = downPoint;
 		setCursor(QCursor(QPixmap(":/new/prefix1/res/pancursor.png")));
+
+		update();
 	}
 	else if ((e->buttons() == Qt::MiddleButton && e->modifiers() & Qt::ControlModifier) || (e->buttons() == Qt::LeftButton && _viewZooming))
 	{
@@ -3650,12 +3654,13 @@ void GLWidget::mouseMoveEvent(QMouseEvent* e)
 
 		_middleButtonPoint = downPoint;
 		setCursor(QCursor(QPixmap(":/new/prefix1/res/zoomcursor.png")));
+
+		update();
 	}
 	else
 	{
 		_lowResEnabled = false;
 	}
-	update();
 }
 
 void GLWidget::wheelEvent(QWheelEvent* e)

--- a/GLWidget.h
+++ b/GLWidget.h
@@ -333,7 +333,7 @@ private:
 	void setupClippingUniforms(QOpenGLShaderProgram* prog, QVector3D pos);
 
 private:
-	QMap<int, bool> _keys;
+	QSet<int> _keys;
 	DisplayMode _displayMode;
 	RenderingMode _renderingMode;
 	QColor      _bgTopColor;


### PR DESCRIPTION
Fixes #5

Applied fixes:
 - do not update main view in GLWidget::performKeyboardNav() when no keys are pressed
 - do not update main view in GLWidget::mouseMoveEvent() when no action takes place